### PR TITLE
Alle Numpad-Ebenen werden von ReNeo verwaltet

### DIFF
--- a/source/mapping.d
+++ b/source/mapping.d
@@ -50,7 +50,7 @@ M['6']              = [mVK("6", '6'),                   mCH("dollar", '$'),     
 M['7']              = [mVK("7", '7'),                   mCH("EuroSign", '€'),           mCH("yen", '¥'),                    mCH("currency", '¤'),               mCH("U03F0", 'ϰ'),             mCH("rightarrow", '→')];
 M['8']              = [mVK("8", '8'),                   mCH("doublelowquotemark", '„'), mCH("singlelowquotemark", '‚'),     mVK("Tab", VK_TAB),                 mCH("leftanglebracket", '⟨'),   mCH("infinity", '∞')];
 M['9']              = [mVK("9", '9'),                   mCH("leftdoublequotemark", '“'),mCH("leftsinglequotemark", '‘'),    mVK("KP_Divide", VK_DIVIDE),        mCH("rightanglebracket", '⟩'),  mCH("variation", '∝')];
-M['0']              = [mVK("0", '0'),                   mCH("rightdoublequotemark", '”'),mCH("rightsinglequotemark", '’'),  mVK("KP_Multiply", VK_MULTIPLY),    mCH("zerosubscript", '₀'),     mCH("emptyset", '∅')];
+M['0']              = [mVK("0", '0'),                   mCH("rightdoublequotemark",'”'),mCH("rightsinglequotemark", '’'),   mVK("KP_Multiply", VK_MULTIPLY),    mCH("zerosubscript", '₀'),     mCH("emptyset", '∅')];
 
 // We need to map Return so that compose knows about it
 M[VK_RETURN]        = [mVK("Return", VK_RETURN),        mVK("Return", VK_RETURN),       mVK("Return", VK_RETURN),           mVK("Return", VK_RETURN),           mVK("Return", VK_RETURN),       mVK("Return", VK_RETURN)];
@@ -77,7 +77,7 @@ M[VK_NUMPAD2]       = [mVK("KP_2", VK_NUMPAD2),         mCH("heart", '♥'),    
 M[VK_NUMPAD3]       = [mVK("KP_3", VK_NUMPAD3),         mCH("U2660", '♠'),              mCH("U21CC", '\u21cc'),             mVK("KP_Page_Down", VK_NEXT),       mCH("greaterthanequal", '≥'),   mCH("U230B", '⌋')];
 
 M[VK_NUMPAD0]       = [mVK("KP_0", VK_NUMPAD0),         mCH("signifblank", '␣'),        mCH("percent", '%'),                mVK("KP_Insert", VK_INSERT),        mCH("permille", '‰'),           mCH("U25A1", '□')];
-M[VK_SEPARATOR]     = [mVK("KP_Separator", VK_SEPARATOR),mVK("KP_Decimal", VK_DECIMAL), mCH("comma", ','),                  mVK("KP_Delete", VK_DELETE),        mCH("minutes", '′'),            mCH("seconds", '″')];
+M[VK_DECIMAL]     =   [mVK("KP_Separator", VK_DECIMAL), mCH("period", '.'),             mVK("comma", VK_OEM_COMMA),         mVK("KP_Delete", VK_DELETE),        mCH("minutes", '′'),            mCH("seconds", '″')];
 
 
 // ***** Layout specific mappings *****
@@ -220,5 +220,5 @@ break;
     NumpadVKMap[VK_HOME]   = VK_NUMPAD7;
     NumpadVKMap[VK_UP]     = VK_NUMPAD8;
     NumpadVKMap[VK_PRIOR]  = VK_NUMPAD9;
-    NumpadVKMap[VK_DELETE] = VK_SEPARATOR;
+    NumpadVKMap[VK_DELETE] = VK_DECIMAL;
 }

--- a/source/mapping.d
+++ b/source/mapping.d
@@ -20,6 +20,8 @@ NeoMap[LayoutName] MAPS;
 const uint KEYSYM_VOID = 0xFFFFFF;
 NeoKey VOID_KEY;
 
+VK[VK] NumpadVKMap;
+
 void initMapping() {
     VOID_KEY = mVK("VoidSymbol", 0xFF);
 
@@ -206,4 +208,17 @@ break;
 
         MAPS[mn] = M;
     }
+
+    // initialize translation map for dual-state Numpad keys
+    NumpadVKMap[VK_INSERT] = VK_NUMPAD0;
+    NumpadVKMap[VK_END]    = VK_NUMPAD1;
+    NumpadVKMap[VK_DOWN]   = VK_NUMPAD2;
+    NumpadVKMap[VK_NEXT]   = VK_NUMPAD3;
+    NumpadVKMap[VK_LEFT]   = VK_NUMPAD4;
+    NumpadVKMap[VK_CLEAR]  = VK_NUMPAD5;
+    NumpadVKMap[VK_RIGHT]  = VK_NUMPAD6;
+    NumpadVKMap[VK_HOME]   = VK_NUMPAD7;
+    NumpadVKMap[VK_UP]     = VK_NUMPAD8;
+    NumpadVKMap[VK_PRIOR]  = VK_NUMPAD9;
+    NumpadVKMap[VK_DELETE] = VK_SEPARATOR;
 }

--- a/source/mapping.d
+++ b/source/mapping.d
@@ -58,10 +58,10 @@ M[VK_TAB]           = [mVK("Tab", VK_TAB),              mVK("Tab", VK_TAB),     
 M[VK_SPACE]         = [mVK("space", VK_SPACE),          mVK("space", VK_SPACE),         mVK("space", VK_SPACE),             mVK("KP_0", VK_NUMPAD0),            mCH("nobreakspace", '\u00a0'),  mCH("U202F", '\u202f')];
 
 M[VK_NUMLOCK]       = [mVK("Tab", VK_TAB),              mVK("Tab", VK_TAB),             mCH("equal", '='),                  mCH("notequal", '≠'),               mCH("U2248", '≈'),              mCH("identical", '≡')];
-M[VK_DIVIDE]        = [mVK("KP_Divide", VK_DIVIDE),     mVK("KP_Divide", VK_DIVIDE),    mCH("division", '÷'),               mCH("U2044", '⁄'),                  mCH("U2300", '⌀'),              mCH("U2223", '∣')];
-M[VK_MULTIPLY]      = [mVK("KP_Multiply", VK_MULTIPLY), mVK("KP_Multiply", VK_MULTIPLY),mCH("U22C5", '\u22c5'),             mCH("multiply", '×'),               mCH("U2299", '\u2299'),         mCH("U2297", '\u2297')];
-M[VK_SUBTRACT]      = [mVK("KP_Subtract", VK_SUBTRACT), mVK("KP_Subtract", VK_SUBTRACT),mCH("U2212", '−'),                  mCH("U2216", '∖'),                  mCH("U2296", '\u2296'),         mCH("U2238", '\u2238')];
-M[VK_ADD]           = [mVK("KP_Add", VK_ADD),           mVK("KP_Add", VK_ADD),          mCH("plusminus", '±'),              mCH("U2213", '∓'),                  mCH("U2295", '\u2295'),         mCH("U2214", '∔')];
+M[VK_DIVIDE]        = [mVK("KP_Divide", VK_DIVIDE),     mCH("slash", '/'),              mCH("division", '÷'),               mCH("U2044", '⁄'),                  mCH("U2300", '⌀'),              mCH("U2223", '∣')];
+M[VK_MULTIPLY]      = [mVK("KP_Multiply", VK_MULTIPLY), mCH("asterisk", '*'),           mCH("U22C5", '\u22c5'),             mCH("multiply", '×'),               mCH("U2299", '\u2299'),         mCH("U2297", '\u2297')];
+M[VK_SUBTRACT]      = [mVK("KP_Subtract", VK_SUBTRACT), mCH("minus", '-'),              mCH("U2212", '−'),                  mCH("U2216", '∖'),                  mCH("U2296", '\u2296'),         mCH("U2238", '\u2238')];
+M[VK_ADD]           = [mVK("KP_Add", VK_ADD),           mCH("plus", '+'),               mCH("plusminus", '±'),              mCH("U2213", '∓'),                  mCH("U2295", '\u2295'),         mCH("U2214", '∔')];
 
 M[VK_NUMPAD7]       = [mVK("KP_7", VK_NUMPAD7),         mCH("U2714", '\u2714'),         mCH("U2195", '↕'),                  mVK("KP_Home", VK_HOME),            mCH("U226A", '\u226a'),         mCH("upstile", '⌈')];
 M[VK_NUMPAD8]       = [mVK("KP_8", VK_NUMPAD8),         mCH("U2718", '\u2718'),         mCH("uparrow", '↑'),                mVK("KP_Up", VK_UP),                mCH("intersection", '∩'),       mCH("U22C2", '⋂')];

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -243,7 +243,10 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
     // Numpad 0-9 and separator are dual-state Numpad keys:
     // scancode range 0x47–0x53 (without 0x4A and 0x4E), no extended scancode
     bool isDualStateNumpadKey = (!extended && scan >= 0x47 && scan <= 0x53 && scan != 0x4A && scan != 0x4E);
-
+    // All Numpad keys including KP_Enter
+    bool isNumpadKey = isDualStateNumpadKey || vk == VK_NUMLOCK || (extended && vk == VK_RETURN) || 
+                       vk == VK_ADD || vk == VK_SUBTRACT || vk == VK_MULTIPLY || vk == VK_DIVIDE;
+                       
     // Deactivate Kana lock if necessary because Kana permanently activates layer 4 in kbdneo
     setKanaState(false);
 
@@ -371,8 +374,8 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
         if (composeResult.type == ComposeResultType.PASS) {
             heldKeys[vk] = nk;
 
-            // translate all layers for dual state Numpad keys
-            if (layer >= 3 || isDualStateNumpadKey) {
+            // Translate all layers for Numpad keys
+            if (layer >= 3 || isNumpadKey) {
                 eat = true;
                 sendNeoKey(nk, true);
             }
@@ -384,7 +387,7 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
             }
         }
     } else {
-        if (layer >= 3) {
+        if (layer >= 3 || isNumpadKey) {
             eat = true;
 
             // release the key that is held for this vk

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -357,6 +357,15 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
         }
     }
 
+    // Handle Numlock key, which would otherwise toggle Numlock state without changing the LED.
+    // For more information see AutoHotkey: https://github.com/Lexikos/AutoHotkey_L/blob/master/source/hook.cpp#L2027
+    if (vk == VK_NUMLOCK && down) {
+        sendVK(VK_NUMLOCK, false);
+        sendVK(VK_NUMLOCK, true);
+        sendVK(VK_NUMLOCK, false);
+        sendVK(VK_NUMLOCK, true);
+    }
+
     // early exit if key is not in map
     if (!(vk in MAPS[activeLayout])) {
         return false;

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -227,6 +227,9 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
     bool down = msg_type == WM_KEYDOWN || msg_type == WM_SYSKEYDOWN;
     // TODO: do we need to use this somewhere?
     bool sys = msg_type == WM_SYSKEYDOWN || msg_type == WM_SYSKEYUP;
+    bool extended = (msg_struct.flags & LLKHF_EXTENDED) > 0;
+    bool altdown = (msg_struct.flags & LLKHF_ALTDOWN) > 0;
+    bool numlock = (GetKeyState(VK_NUMLOCK) & 0xFFFF) != 0;
 
     // ignore all simulated keypresses
     if (vk == VK_PACKET || (msg_struct.flags & LLKHF_INJECTED)) {


### PR DESCRIPTION
Wenn Numlock aktiviert ist und Shift gedrückt wird, schaltet der Tastaturtreiber in einen Modus, bei dem die VKs für Navigationstasten gesendet werden, anstelle der Numpad-Zifferntasten. Dies wollen wir erkennen und umgehen.

Der Tastaturtreiber erzeugt beim Drücken von Shift und einer entsprechenden Numpadtaste zunächst einen Fake-ShiftUp-Scancode (nicht injected), der erkannt wird. Anschließend wird der (aus unserer Sicht) falsche Virtual Key durch den gewünschten ersetzt und die weitere Verarbeitung fortgesetzt. Beim Keyup sendet der Tastaturtreiber zunächst den echten ShiftDown, was aber kein Problem ist, da Shift ja sowieso gedrückt ist. Hier ist keine zusätzliche Behandlung notwendig.

Die Numpadtasten mit zwei States sind Num0–Num9 und der Dezimalpunkt. Ich habe aber für alle Numpad-Keys (also auch Numlock, die Rechenzeichen und das Num-Enter) jeweils alle Ebenen zu Reneo gepackt, weil in kbdneo für Numpad die Ebenen 2 und 4 vertauscht sind. Das ReNeo-Mapping ist angepasst von VK_* auf Unicode-Zeichen (sonst hätte Shift+VK_* nämlich das in kbdneo für Shift definierte Zeichen gesendet, was aber wegen der Vertauschung das Zeichen von Ebene 4 ist).

- Das Mapping für `VK_SEPARATOR` habe ich zu `VK_DECIMAL` umgestellt (Windows sendet diesen Virtual Key). Der Name `KP_Separator` ist von xkb, und der VK_SEPARATOR scheint eine andere Bedeutung zu haben in Windows.
- Numlock ist bei aktiviertem Keyboardhook immer eingeschaltet. Der vorherige Zustand wird gemerkt und bei Deaktivierung wiederhergestellt. Dies gilt auch für den Bypassmode durch Layoutwechsel.

Fixes #7