### PR TITLE
Viele Bugfixes hauptsächlich in sendUTF16OrKeyCombo()

### DIFF
--- a/source/reneo.d
+++ b/source/reneo.d
@@ -230,7 +230,13 @@ void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
     // warning: this is only an approximation. whether capslock affects this key is dependent on the native layout
     // this means sometimes we need to invert capslock with shift, sometimes not... as of yet this is an open issue.
     //
-    // Only add Shift if the virtual key combination either needs Shift or does not need any modifiers (but capslock is on).
+    // Only add Shift in two cases:
+    // (1) Capslock is disabled. If the virtual key combination needs Shift, it will be injected.
+    // (2) Capslock is enabled. Only if the virtual key combination needs no modifiers (Shift/Alt/Ctrl),
+    //     it will be injected. The shift state and the capslock state will cancel each other out.
+    // (2.1) If the key combination requires only Shift, the capslock state works as active Shift key.
+    // (2.2) If higher modifiers Ctrl or Alt are involved, the capslock state has no effect.
+    // So for cases 2.1 and 2.2, no additional Shift is sent.
     if ((shift && !capslock) || (high == 0 && capslock)) {
         input_struct.ki.wVk = VK_SHIFT;
         input_struct.ki.wScan = 0x2A;
@@ -572,10 +578,10 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
     // Handle Numlock key, which would otherwise toggle Numlock state without changing the LED.
     // For more information see AutoHotkey: https://github.com/Lexikos/AutoHotkey_L/blob/master/source/hook.cpp#L2027
     if (vk == VKEY.VK_NUMLOCK && down) {
-        sendVK(VK_NUMLOCK, Scancode(0, false), false);
-        sendVK(VK_NUMLOCK, Scancode(0, false), true);
-        sendVK(VK_NUMLOCK, Scancode(0, false), false);
-        sendVK(VK_NUMLOCK, Scancode(0, false), true);
+        sendVK(VK_NUMLOCK, scanNumlock, false);
+        sendVK(VK_NUMLOCK, scanNumlock, true);
+        sendVK(VK_NUMLOCK, scanNumlock, false);
+        sendVK(VK_NUMLOCK, scanNumlock, true);
     }
 
     // early exit if key is not in map

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -496,15 +496,6 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
         return true;
     }
 
-    // Handle Numlock key, which would otherwise toggle Numlock state without changing the LED.
-    // For more information see AutoHotkey: https://github.com/Lexikos/AutoHotkey_L/blob/master/source/hook.cpp#L2027
-    if (vk == VKEY.VK_NUMLOCK && down) {
-        sendVK(VK_NUMLOCK, Scancode(0, false), false);
-        sendVK(VK_NUMLOCK, Scancode(0, false), true);
-        sendVK(VK_NUMLOCK, Scancode(0, false), false);
-        sendVK(VK_NUMLOCK, Scancode(0, false), true);
-    }
-
     // early exit if key is not in map
     if (!(scan in activeLayout.map)) {
         return false;

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -152,7 +152,13 @@ void sendUTF16(wchar unicode_char, bool down) nothrow {
 
 void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
     /// Send a native key combo if there is one in the current layout, otherwise send unicode directly
-    debug_writeln("Trying to send ", unicode_char);
+    debug {
+        try {
+            writeln(format("Trying to send %s (0x%04X) ...", unicode_char, to!int(unicode_char)));
+        }
+        catch (Exception e) {}
+    }
+
     short result = VkKeyScan(unicode_char);
     ubyte low = cast(ubyte) result;
     ubyte high = cast(ubyte) (result >> 8);
@@ -167,8 +173,22 @@ void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
 
     if (low == 0xFF || kana || mod5 || mod6) {
         // char does not exist in native layout or requires exotic modifiers
+        debug_writeln("No standard key combination found, sending via VK packet");
         sendUTF16(unicode_char, down);
         return;
+    }
+
+    debug {
+        try {
+            auto shift_text = shift ? "(Shift) " : "        ";
+            auto ctrl_text  = ctrl  ? "(Ctrl)  " : "        ";
+            auto alt_text   = alt   ? "(Alt)   " : "        ";
+            auto kana_text  = kana  ? "(Kana)  " : "        ";
+            auto mod5_text  = mod5  ? "(Mod5)  " : "        ";
+            auto mod6_text  = mod6  ? "(Mod6)  " : "        ";
+            debug_writeln("Key combination is " ~ to!string(cast(VKEY) vk) ~ " "
+                ~ shift_text ~ ctrl_text ~ alt_text ~ kana_text ~ mod5_text ~ mod6_text);
+        } catch (Exception ex) {}
     }
 
     INPUT[] inputs;

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -149,8 +149,8 @@ void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
     /// Send a native key combo if there is one in the current layout, otherwise send unicode directly
     debug_writeln("Trying to send ", unicode_char);
     short result = VkKeyScan(unicode_char);
-    byte low = cast(byte) result;
-    byte high = cast(byte) (result >> 8);
+    ubyte low = cast(ubyte) result;
+    ubyte high = cast(ubyte) (result >> 8);
 
     short vk = low;
     bool shift = (high & 1) != 0;
@@ -160,7 +160,7 @@ void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
     bool mod5 = (high & 16) != 0;
     bool mod6 = (high & 32) != 0;
 
-    if (low == -1 || kana || mod5 || mod6) {
+    if (low == 0xFF || kana || mod5 || mod6) {
         // char does not exist in native layout or requires exotic modifiers
         sendUTF16(unicode_char, down);
         return;

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -178,6 +178,13 @@ void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
         input_struct.ki.dwFlags = KEYEVENTF_KEYUP;
     }
 
+    // For up events, release the main key before the modifiers
+    if (!down) {
+        input_struct.ki.wVk = vk;
+        input_struct.ki.wScan = cast(ushort) MapVirtualKey(vk, MAPVK_VK_TO_VSC);
+        inputs ~= input_struct;
+    }
+
     // modifiers
     // pay attention to current capslock state
     // warning: this is only an approximation. whether capslock affects this key is dependent on the native layout
@@ -207,10 +214,12 @@ void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
         }
     }
 
-    // main key
-    input_struct.ki.wVk = vk;
-    input_struct.ki.wScan = cast(ushort) MapVirtualKey(vk, MAPVK_VK_TO_VSC);
-    inputs ~= input_struct;
+    // For down events, set the main key after the modifiers
+    if (down) {
+        input_struct.ki.wVk = vk;
+        input_struct.ki.wScan = cast(ushort) MapVirtualKey(vk, MAPVK_VK_TO_VSC);
+        inputs ~= input_struct;
+    }
 
     SendInput(cast(uint) inputs.length, inputs.ptr, INPUT.sizeof);
 }

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -569,6 +569,15 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
         return true;
     }
 
+    // Handle Numlock key, which would otherwise toggle Numlock state without changing the LED.
+    // For more information see AutoHotkey: https://github.com/Lexikos/AutoHotkey_L/blob/master/source/hook.cpp#L2027
+    if (vk == VKEY.VK_NUMLOCK && down) {
+        sendVK(VK_NUMLOCK, Scancode(0, false), false);
+        sendVK(VK_NUMLOCK, Scancode(0, false), true);
+        sendVK(VK_NUMLOCK, Scancode(0, false), false);
+        sendVK(VK_NUMLOCK, Scancode(0, false), true);
+    }
+
     // early exit if key is not in map
     if (!(scan in activeLayout.map)) {
         return false;

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -236,24 +236,15 @@ void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
         input_struct.ki.wScan = 0x2A;
         inputs ~= input_struct;
     }
-    if (ctrl && alt) {
-        // Send right alt key (extended), which will automatically generate fake left ctrl
+    if (ctrl) {
+        input_struct.ki.wVk = VK_CONTROL;
+        input_struct.ki.wScan = 0x1D;
+        inputs ~= input_struct;
+    }
+    if (alt) {
         input_struct.ki.wVk = VK_MENU;
         input_struct.ki.wScan = 0x38;
-        input_struct.ki.dwFlags |= KEYEVENTF_EXTENDEDKEY;
         inputs ~= input_struct;
-        input_struct.ki.dwFlags &= ~KEYEVENTF_EXTENDEDKEY;
-    } else {
-        if (ctrl) {
-            input_struct.ki.wVk = VK_CONTROL;
-            input_struct.ki.wScan = 0x1D;
-            inputs ~= input_struct;
-        }
-        if (alt) {
-            input_struct.ki.wVk = VK_MENU;
-            input_struct.ki.wScan = 0x38;
-            inputs ~= input_struct;
-        }
     }
 
     // For down events, set the main key after the modifiers
@@ -417,7 +408,6 @@ bool rightMod4Down;
 
 bool capslock;
 bool mod4Lock;
-bool unpressFakeLCtrl;
 
 uint previousLayer = 1;
 
@@ -457,12 +447,6 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
         } catch(Exception e) {}
     }
 
-    // AltGr handling: eat injected AltGr-up event, if it was send for unpress fake LCtrl
-    if (scan == scanAltGr && !down && injected && unpressFakeLCtrl) {
-        unpressFakeLCtrl = false;
-        return true;
-    }
-    
     // ignore all simulated keypresses
     if (vk == VKEY.VK_PACKET || injected) {
         return false;
@@ -480,10 +464,9 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
     // We want Numlock to be always off so that we don't get fake shift events on layer 2
     setNumlockState(false);
 
-    // Do not change fake LCtrl but skip processing here. The key is necessary for LCtrl/RAlt combinations
-    // in standalone mode, for characters like @ or ~.
+    // Disable fake LCTRL on AltGr as we use that for Mod4
     if (scan.scan == SC_FAKE_LCTRL) {
-        return false;
+        return true;
     }
 
     // was the pressed key a NEO modifier (M3 or M4)? Because we don't want to send those to applications.
@@ -572,16 +555,6 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
     }
     bool changedLayer = patchedLayer != previousLayer;
     previousLayer = patchedLayer;
-
-    // AltGr handling:
-    // Pressing physical AltGr on some layouts triggers a fake LCtrl-down, which we do not want here.
-    // So we send immediate AltGr-up to trigger the corresponding LCtrl-up. This way the ctrl key
-    // is not being (virtually) held for possible Mod4 key combinations.  We also need to catch
-    // this additional AltGr-up in the next hook call, which is indicated by unpressFakeLCtrl.
-    if (scan == scanAltGr && vk == VKEY.VK_RMENU && down) {
-        unpressFakeLCtrl = true;
-        sendVK(VK_RMENU, scan, false);
-    }
 
     // if we switched layers release all currently held keys
     if (changedLayer) {

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -17,6 +17,11 @@ const SC_FAKE_LSHIFT = 0x22A;
 const SC_FAKE_RSHIFT = 0x236;
 const SC_FAKE_LCTRL = 0x21D;
 
+Scancode scanCapslock = Scancode(0x3A, false);
+Scancode scanAltGr = Scancode(0x38, true);
+Scancode scanLCtrl = Scancode(0x1D, false);
+Scancode scanNumlock = Scancode(0x45, true);
+
 void debug_writeln(T...)(T args) {
     debug {
         writeln(args);
@@ -228,11 +233,11 @@ void sendNeoKey(NeoKey nk, Scancode realScan, bool down) nothrow {
         } else if (nk.vk_code == VKEY.VK_UNDO) {
             if (down) {
                 // TODO: fix scancodes
-                sendVK(VK_CONTROL, Scancode(0, false), true);
-                sendVK('Z', Scancode(0, false), true);
+                sendVK(VK_CONTROL, scanLCtrl, true);
+                sendVK('Z', Scancode(MapVirtualKey(VKEY.VK_KEY_Z, MAPVK_VK_TO_VSC), false), true);
             } else {
-                sendVK('Z', Scancode(0, false), false);
-                sendVK(VK_CONTROL, Scancode(0, false), false);
+                sendVK('Z', Scancode(MapVirtualKey(VKEY.VK_KEY_Z, MAPVK_VK_TO_VSC), false), false);
+                sendVK(VK_CONTROL, scanLCtrl, false);
             }
         } else {
             return;
@@ -320,8 +325,8 @@ bool getNumlockState() nothrow {
 
 void setNumlockState(bool state) nothrow {
     if (getNumlockState() != state) {
-        sendVK(VK_NUMLOCK, Scancode(0, false), true);
-        sendVK(VK_NUMLOCK, Scancode(0, false), false);
+        sendVK(VK_NUMLOCK, scanNumlock, true);
+        sendVK(VK_NUMLOCK, scanNumlock, false);
     }
 }
 
@@ -408,15 +413,15 @@ bool keyboardHook(WPARAM msg_type, KBDLLHOOKSTRUCT msg_struct) nothrow {
         // CAPSLOCK by pressing both Shift keys
         // leftShiftDown contains previous state
         if (!leftShiftDown && down && rightShiftDown) {
-            sendVK(VK_CAPITAL, Scancode(0, false), true);
-            sendVK(VK_CAPITAL, Scancode(0, false), false);
+            sendVK(VK_CAPITAL, scanCapslock, true);
+            sendVK(VK_CAPITAL, scanCapslock, false);
         }
 
         leftShiftDown = down;
     } else if (scan == activeLayout.modifiers.shiftRight && scan.scan != SC_FAKE_RSHIFT) {
         if (!rightShiftDown && down && leftShiftDown) {
-            sendVK(VK_CAPITAL, Scancode(0, false), true);
-            sendVK(VK_CAPITAL, Scancode(0, false), false);
+            sendVK(VK_CAPITAL, scanCapslock, true);
+            sendVK(VK_CAPITAL, scanCapslock, false);
         }
 
         rightShiftDown = down;


### PR DESCRIPTION
- VkKeyScan und die positive 255 ;)
- Numlock braucht anscheinend keine Spezialbehandlung mehr (2x down/up), seitdem es (a) permanent aus ist und (b) bei jedem Tastendruck geprüft wird. Allerdings kann ich auch nicht mehr sagen, was der Auslöser dafür war
- viele manuell gesendete Keys hatten noch keinen Scancode (der war 0). Den habe ich der Taste entsprechend eingesetzt, z.B. Capslock, aber auch für Strg-Z (layoutabhängig)
- Für sendUTF16OrKeyCombo wurde die AltGr-Behandlung (wie neulich besprochen) Windows-konformer umgesetzt. Für die Fake LCtrl und von uns gesendete AltGr-Up-Events braucht es dann wiederum ein paar extra Fälle (nichts kompliziertes).
- Beim Loslassen von generierten Key Combos wird erst die Haupttaste, danach die Modifier losgelassen.
- Spezialfall mit Shift, wenn dies bereits gedrückt ist, aber die generierte Kombination kein Shift benötigt: dann braucht es erst ein Shift-Up und hinterher wieder Shift-Down.