### PR TITLE
Faster loading

### DIFF
--- a/source/composer.d
+++ b/source/composer.d
@@ -124,6 +124,7 @@ struct ComposeNode {
 }
 
 ComposeNode composeRoot;
+ComposeNode removeComposeRoot;
 
 bool active;
 ComposeNode *currentNode;
@@ -149,6 +150,9 @@ struct ComposeFileLine {
     wstring result;
 }
 
+
+uint addedEntries;
+
 void initCompose(string exeDir) {
     debug_writeln("Initializing compose");
 
@@ -164,41 +168,30 @@ void initCompose(string exeDir) {
         return;
     }
 
-    ComposeFileLine[] combinedComposeEntries;
-    ComposeFileLine[] entriesToRemove;
+    // Gather all entries that appear in .remove files
+    foreach (dirEntry; dirEntries(composeDir, "*.remove", SpanMode.shallow)) {
+        if (dirEntry.isFile) {
+            string fname = dirEntry.name;
+            debug_writeln("Removing compose module ", fname);
+            loadRemoveModule(fname);
+        }
+    }
 
     // Gather compose entries from all .module files
     foreach (dirEntry; dirEntries(composeDir, "*.module", SpanMode.shallow)) {
         if (dirEntry.isFile) {
             string fname = dirEntry.name;
             debug_writeln("Loading compose module ", fname);
-            combinedComposeEntries ~= loadModule(fname);
+            loadModule(fname);
         }
     }
-
-    // Filter all entries that appear in .remove files
-    foreach (dirEntry; dirEntries(composeDir, "*.remove", SpanMode.shallow)) {
-        if (dirEntry.isFile) {
-            string fname = dirEntry.name;
-            debug_writeln("Removing compose module ", fname);
-            entriesToRemove ~= loadModule(fname);
-        }
-    }
-    combinedComposeEntries = combinedComposeEntries.filter!(e => !entriesToRemove.canFind(e)).array;
 
     debug {
         debug_writeln("Time spent reading and parsing module files: ", sw.peek().total!"msecs", " ms");
         sw.reset();
     }
 
-    // Build compose tree consisting of all entries
-    foreach (entry; combinedComposeEntries) {
-        addComposeEntry(entry);
-    }
-
-    debug {
-        debug_writeln("Time spent building compose tree: ", sw.peek().total!"msecs", " ms");
-    }
+    debug_writeln("Loaded ", addedEntries, " compose sequences.");
 }
 
 ComposeFileLine parseLine(string line) {
@@ -213,8 +206,29 @@ ComposeFileLine parseLine(string line) {
     return entry;
 }
 
-void addComposeEntry(ComposeFileLine entry) {
-    auto currentNode = &composeRoot;
+bool isEntryInComposeTree(ComposeFileLine entry, ref ComposeNode nodeRoot) {
+    auto currentNode = &nodeRoot;
+
+    foreach (keysym; entry.keysyms) {
+        ComposeNode *next;
+        bool foundNext;
+
+        foreach (nextIter; currentNode.next) {
+            if (nextIter.keysym == keysym) {
+                foundNext = true;
+                next = nextIter;
+                break;
+            }
+        }
+        if (!foundNext) break;
+        currentNode = next;
+    }
+
+    return (currentNode.result == entry.result);
+}
+
+void addComposeEntry(ComposeFileLine entry, ref ComposeNode nodeRoot) {
+    auto currentNode = &nodeRoot;
 
     foreach (keysym; entry.keysyms) {
         ComposeNode *next;
@@ -250,22 +264,35 @@ void addComposeEntry(ComposeFileLine entry) {
     currentNode.result = entry.result;
 }
 
-
-ComposeFileLine[] loadModule(string fname) {
-    ComposeFileLine[] entries;
-
-    /// Load a module file and return all entries
+void loadModule(string fname) {
+    /// Load a module file and add all entries, if they are not in the remove-tree
     string content = cast(string) std.file.read(fname);
     string[] lines = split(content, "\n");
     foreach(l; lines) {
         try {
-            entries ~= parseLine(l);
+            auto entry = parseLine(l);
+            if (!isEntryInComposeTree(entry, removeComposeRoot)) {
+                addComposeEntry(entry, composeRoot);
+                addedEntries += 1;
+            }
         } catch (Exception e) {
             // Do nothing, most likely because the line just was a comment
         }
     }
+}
 
-    return entries;
+void loadRemoveModule(string fname) {
+    /// Load a module file and add all entries to the remove-tree
+    string content = cast(string) std.file.read(fname);
+    string[] lines = split(content, "\n");
+    foreach(l; lines) {
+        try {
+            auto entry = parseLine(l);
+            addComposeEntry(entry, removeComposeRoot);
+        } catch (Exception e) {
+            // Do nothing, most likely because the line just was a comment
+        }
+    }
 }
 
 ComposeResult compose(NeoKey nk) nothrow {

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -58,8 +58,7 @@ void initKeysyms(string exeDir) {
     auto keysymfile = buildPath(exeDir, "keysymdef.h");
     debug_writeln("Initializing keysyms from ", keysymfile);
     // group 1: name, group 2: hex, group 3: unicode codepoint
-    auto unicode_pattern = r"^\#define XK_([a-zA-Z_0-9]+)\s+0x([0-9a-f]+)\s*\/\* U\+([0-9A-F]{4,6}) (.*) \*\/\s*$";
-    auto unicode_pattern_with_parens = r"^\#define XK_([a-zA-Z_0-9]+)\s+0x([0-9a-f]+)\s*\/\*\(U\+([0-9A-F]{4,6}) (.*)\)\*\/\s*$";
+    auto unicode_pattern = r"^\#define XK_([a-zA-Z_0-9]+)\s+0x([0-9a-f]+)\s*\/\*[ \(]U\+([0-9A-F]{4,6}) (.*)[ \)]\*\/\s*$";
     // group 1: name, group 2: hex, group 3 and 4: comment stuff
     auto no_unicode_pattern = r"^\#define XK_([a-zA-Z_0-9]+)\s+0x([0-9a-f]+)\s*(\/\*\s*(.*)\s*\*\/)?\s*$";
     keysyms_by_name.clear();
@@ -70,12 +69,6 @@ void initKeysyms(string exeDir) {
 		string l = f.readln();
         try {
             if (auto m = matchFirst(l, unicode_pattern)) {
-                string keysym_name = m[1];
-                uint key_code = to!uint(m[2], 16);
-                uint codepoint = to!uint(m[3], 16);
-                keysyms_by_name[keysym_name] = key_code;
-                keysyms_by_codepoint[codepoint] = key_code;
-            } else if (auto m = matchFirst(l, unicode_pattern_with_parens)) {
                 string keysym_name = m[1];
                 uint key_code = to!uint(m[2], 16);
                 uint codepoint = to!uint(m[3], 16);


### PR DESCRIPTION
Zunächst die ersten zwei Commits:
- Für die `.remove`-Dateien ist es unerheblich, in welcher Reihenfolge sie geladen werden. Daher habe ich die Filterung in einen gemeinsamen Schritt verschoben.
- Dateien komplett einzulesen ist schneller, und die paar MB hat man doch im RAM übrig
- Parsen der Keysyms scheint _deutlich_ effizienter zu sein, wenn man die RegEx für beide Unicode-Varianten zusammenfasst

Der letzte Commit lädt die Sachen direkt in den Baum, muss dafür aber die remove-Dateien zuerst abspeichern. Ich habe das mit einem zweiten Baum gelöst, in dem dann geguckt wird, ob ein entsprechender Eintrag existiert. Wenn ja, wird ein Eintrag (aus `.module`) nicht übernommen.