### PR TITLE
Korrekten Capslock-State berücksichtigen im Standalone-Modus

### DIFF
--- a/source/reneo.d
+++ b/source/reneo.d
@@ -211,12 +211,13 @@ void sendUTF16OrKeyCombo(wchar unicode_char, bool down) nothrow {
     // is active), the key is capslockable.
     // The other way round, if a key is not capslockable, the Capslock state must not be considered.
 
-    // On capslock disabled, this flag is set to false in both cases (simplifies the XOR later).
-    bool notCapslockable = (buf[0] == unicode_char) && capslock;
+    // This flag is set to false if Capslock is not active. This is because the capslockable state
+    // can only be checked when Capslock is active (and only then has any influence).
+    bool nativeCapslockable = (buf[0] != unicode_char) && capslock;
     // Is any Shift key pressed physically?
     bool shiftDown = leftShiftDown || rightShiftDown;
-    // Calculate the overall Shift state from the flags described, using XOR
-    bool overallShift = shiftDown ^ capslock ^ notCapslockable;
+    // Calculate the overall Shift state from the flags described
+    bool overallShift = (!nativeCapslockable && shiftDown) || (nativeCapslockable && (shiftDown ^ capslock));
     bool unpressShift = false;
 
     // If the required and the current Shift states differ, the current Shift state is changed


### PR DESCRIPTION
Für den Standalone-Modus wird in `sendUTF16OrKeyCombo()` versucht, die native Tastenkombination zu drücken. Dabei spielen eine (physikalisch) gedrückte Shifttaste, der Capslock-Status und die Frage, ob eine Taste „capslock-fähig“ ist, jeweils eine Rolle. Über `toUnicode()` kann man rückwärts herausfinden, ob die native Tastenkombination das gewünschte Zeichen ausgibt. Dabei wird der Capslock-State mit angegeben. Ergibt sich dabei ein anderes Zeichen (und Capslock ist gedrückt), dann wird diese Taste durch Capslock beeinflusst.

Für die Frage, ob nun zusätzlich (virtuell) Shift gedrückt werden muss, habe ich keine State Machine mit 8 oder 16 Kombinationen (von denen man nichtmal alle testen kann) verwendet, sondern die drei Kriterien logisch verknüpft. Am Ende ergibt sich, ob ein zusätzliches Shift erforderlich ist. Falls bereits die Shifttaste gedrückt ist, muss sie natürlich temporär losgelassen werden.

Meine Tests waren in allen Belangen erfolgreich, bspw. mit dem Bindestrich und Unterstrich, oder auch mit Shift+6 bei gleichzeitigem Capslock (soll Dollarzeichen ergeben). Auch das Eurozeichen klappt weiterhin (Shift-7 oder Shift-Num5). Erklärende Kommentare stehen auch im Quellcode.