### PR TITLE
Nicht definierte Keys benötigen den korrekten VK

### DIFF
--- a/source/mapping.d
+++ b/source/mapping.d
@@ -271,6 +271,7 @@ void initLayouts(JSONValue jsonLayoutArray) {
 
 NeoKey parseNeoKey(JSONValue jsonKey) {
     NeoKey key;
+    key.vk_code = VKEY.VK_VOID;
     
     if ("keysym" in jsonKey) {
         key.keysym = parseKeysym(jsonKey["keysym"].str);
@@ -285,7 +286,6 @@ NeoKey parseNeoKey(JSONValue jsonKey) {
         key.keytype = NeoKeyType.CHAR;
         key.char_code = jsonKey["char"].str.to!wstring[0];
     }
-
 
     return key;
 }


### PR DESCRIPTION
Der Enum `vk_code` wird bisher mit dem ersten Eintrag initialisiert, der hier aber VK_LBUTTON ist, statt des gewünschten VK_VOID. Führte bei mir zunächst zu Rätselraten, als ich eine vermeintlich leere Taste drückte und das Fenster wechselte …