### PR TITLE
Parse-Bugfix

### DIFF
--- a/source/composer.d
+++ b/source/composer.d
@@ -90,6 +90,11 @@ class ComposeParser {
         }
         string stringContent = endChunk();
         match('"');
+        if (stringContent == r"\") {
+            stringContent = "\"";
+        } else if (stringContent == r"\\") {
+            stringContent = r"\";
+        }
         return stringContent;
     }
 

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -58,9 +58,9 @@ void initKeysyms(string exeDir) {
     auto keysymfile = buildPath(exeDir, "keysymdef.h");
     debug_writeln("Initializing keysyms from ", keysymfile);
     // group 1: name, group 2: hex, group 3: unicode codepoint
-    auto unicode_pattern = r"^\#define XK_([a-zA-Z_0-9]+)\s+0x([0-9a-f]+)\s*\/\*[ \(]U\+([0-9A-F]{4,6}) (.*)[ \)]\*\/\s*$";
+    auto unicode_pattern = r"^\#define XK_([a-zA-Z_0-9]+)\s+0x([0-9a-fA-F]+)\s*\/\*[ \(]U\+([0-9a-fA-F]{4,6}) (.*)[ \)]\*\/\s*$";
     // group 1: name, group 2: hex, group 3 and 4: comment stuff
-    auto no_unicode_pattern = r"^\#define XK_([a-zA-Z_0-9]+)\s+0x([0-9a-f]+)\s*(\/\*\s*(.*)\s*\*\/)?\s*$";
+    auto no_unicode_pattern = r"^\#define XK_([a-zA-Z_0-9]+)\s+0x([0-9a-fA-F]+)\s*(\/\*\s*(.*)\s*\*\/)?\s*$";
     keysyms_by_name.clear();
     keysyms_by_codepoint.clear();
 


### PR DESCRIPTION
Zwei kleine Fixes für die Behandlung der Keysyms bzw. Sonderfälle in .module-Dateien. Bei letzterem hab ich erst versucht, den Backslash als Escape-Zeichen zu behandeln, aber das führte zu deutlich aufwendigerem Code, und faktisch betrifft es nur genau die Fälle mit `\\` und `\"` (was zu `\` wird nach dem Parserdurchlauf. Die hab ich direkt ersetzt.

Die Keysyms hatten nur Probleme mit großen Hexzahlen (A-F). Hab das in der RegEx ergänzt.