### PR TITLE
Debug Builds: SetConsole{,Output}CP to UTF-8

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -664,6 +664,14 @@ JSONValue parseJSONFile(string jsonFilename) {
 }
 
 void main(string[] args) {
+    debug {
+        const auto codePage = CP_UTF8;
+        if (!SetConsoleCP(codePage))
+            debugWriteln("WARNING: Could not set input CP to UTF-8. This probably doesn’t matter.");
+        if (!SetConsoleOutputCP(codePage))
+            debugWriteln("WARNING: Could not set output CP to UTF-8. Some characters may be displayed wrongly.");
+    }
+
     debugWriteln("Starting ReNeo...");
     version(FileLogging) {
         debugWriteln("WARNING: File logging enabled, make sure you know what you're doing!");


### PR DESCRIPTION
Diese Änderung setzt die CodePage für das Konsolenfenster auf UTF-8, damit geloggte Texte richtig angezeigt werden.

Ich habe leider auf die Schnelle in MS’ Doku nicht sicher gefunden ab wann es die Codepage gibt. ~Eventuell ab 1903.~ (War ungenau gelesen.) Ist diese Einschränkung akzeptabel?

Behebt teilweise #93.