### PR TITLE
Added config option for osk transparency and ability to change that via hotkeys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  workflow_dispatch:
   push:
     tags:
     - 'v*'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@ name: Release
 on:
   workflow_dispatch:
   push:
-    tags:
-    - 'v*'
 jobs:
   build-release:
     runs-on: windows-latest
@@ -40,23 +38,8 @@ jobs:
         run: mv -Force config.neoqwertz.json ReNeo\config.default.json
       - name: Create NeoQwertz ZIP file
         run: 7z a -tzip ReNeo_NeoQwertz.zip ReNeo\
-      - name: Replace config.default.json with Bone config
-        run: mv -Force config.bone.json ReNeo\config.default.json
-      - name: Create Bone ZIP file
-        run: 7z a -tzip ReNeo_Bone.zip ReNeo\
-      - name: Replace config.default.json with 3l config
-        run: mv -Force config.3l.json ReNeo\config.default.json
-      - name: Create 3l ZIP file
-        run: 7z a -tzip ReNeo_3l.zip ReNeo\
-      - name: Create Release
-        uses: marvinpinto/action-automatic-releases@v1.2.1
+      - uses: actions/upload-artifact@v3
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          draft: true
-          prerelease: false
-          files: |
-            ReNeo_Neo.zip
-            ReNeo_NeoQwertz.zip
-            ReNeo_Bone.zip
-            ReNeo_3l.zip
-      
+          name: ReNeo_NeoQwertz.zip
+          path: ReNeo_NeoQwertz.zip
+          retention-days: 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 on:
-  workflow_dispatch:
   push:
+    tags:
+    - 'v*'
 jobs:
   build-release:
     runs-on: windows-latest
@@ -38,8 +39,23 @@ jobs:
         run: mv -Force config.neoqwertz.json ReNeo\config.default.json
       - name: Create NeoQwertz ZIP file
         run: 7z a -tzip ReNeo_NeoQwertz.zip ReNeo\
-      - uses: actions/upload-artifact@v3
+      - name: Replace config.default.json with Bone config
+        run: mv -Force config.bone.json ReNeo\config.default.json
+      - name: Create Bone ZIP file
+        run: 7z a -tzip ReNeo_Bone.zip ReNeo\
+      - name: Replace config.default.json with 3l config
+        run: mv -Force config.3l.json ReNeo\config.default.json
+      - name: Create 3l ZIP file
+        run: 7z a -tzip ReNeo_3l.zip ReNeo\
+      - name: Create Release
+        uses: marvinpinto/action-automatic-releases@v1.2.1
         with:
-          name: ReNeo_NeoQwertz.zip
-          path: ReNeo_NeoQwertz.zip
-          retention-days: 2
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          draft: true
+          prerelease: false
+          files: |
+            ReNeo_Neo.zip
+            ReNeo_NeoQwertz.zip
+            ReNeo_Bone.zip
+            ReNeo_3l.zip
+      

--- a/config.3l.json
+++ b/config.3l.json
@@ -10,7 +10,8 @@
         "theme": "Grey",
         "layout": "ansi",
         "numberRow": false,
-        "modifierNames": "three"
+        "modifierNames": "three",
+        "transparencyPercent": "90"
     },
     "hotkeys": {
         "toggleActivation": "Shift+Pause",

--- a/config.bone.json
+++ b/config.bone.json
@@ -10,7 +10,8 @@
         "theme": "ColorClassic",
         "layout": "iso",
         "numberRow": true,
-        "modifierNames": "standard"
+        "modifierNames": "standard",
+        "transparencyPercent": "90"
     },
     "hotkeys": {
         "toggleActivation": "Shift+Pause",

--- a/config.default.json
+++ b/config.default.json
@@ -10,7 +10,8 @@
         "theme": "ColorClassic",
         "layout": "iso",
         "numberRow": true,
-        "modifierNames": "standard"
+        "modifierNames": "standard",
+        "transparencyPercent": "90"
     },
     "hotkeys": {
         "toggleActivation": "Shift+Pause",

--- a/config.neo.json
+++ b/config.neo.json
@@ -10,7 +10,8 @@
         "theme": "ColorClassic",
         "layout": "iso",
         "numberRow": true,
-        "modifierNames": "standard"
+        "modifierNames": "standard",
+        "transparencyPercent": "90"
     },
     "hotkeys": {
         "toggleActivation": "Shift+Pause",

--- a/config.neoqwertz.json
+++ b/config.neoqwertz.json
@@ -10,7 +10,8 @@
         "theme": "Grey",
         "layout": "iso",
         "numberRow": true,
-        "modifierNames": "standard"
+        "modifierNames": "standard",
+        "transparencyPercent": "90"
     },
     "hotkeys": {
         "toggleActivation": "Shift+Pause",

--- a/source/osk.d
+++ b/source/osk.d
@@ -79,6 +79,12 @@ void initOsk(JSONValue oskJson) {
     configOskLayout = oskJson["layout"].str.toUpper.to!OSKLayout;
     configOskNumberRow = oskJson["numberRow"].boolean;
     configOskModifierNames = oskJson["modifierNames"].str.toUpper.to!OSKModifierNames;
+    configOskTransparancy = (configOskTheme == OSKTheme.Grey) ? 0.9 : 0.95;
+    if (oskJson["transparency"].type == JSONType.float_) {
+        configOskTransparancy = oskJson["transparency"].floating;
+    } else if (oskJson["transparency"].type == JSONType.integer) {
+        configOskTransparancy = cast(float)oskJson["transparency"].integer;
+    }
 
     // Load fonts
     WIN_FONTS ~= CreateFont(0, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE, ANSI_CHARSET, OUT_DEFAULT_PRECIS,

--- a/source/osk.d
+++ b/source/osk.d
@@ -80,6 +80,7 @@ void initOsk(JSONValue oskJson) {
     configOskLayout = oskJson["layout"].str.toUpper.to!OSKLayout;
     configOskNumberRow = oskJson["numberRow"].boolean;
     configOskModifierNames = oskJson["modifierNames"].str.toUpper.to!OSKModifierNames;
+    configOskTransparency = 0;
     updateOSKTransparency(oskJson["transparencyPercent"].str.to!int);
 
     // Load fonts

--- a/source/osk.d
+++ b/source/osk.d
@@ -32,7 +32,7 @@ OSKTheme configOskTheme;
 OSKLayout configOskLayout;
 bool configOskNumberRow;
 OSKModifierNames configOskModifierNames;
-float configOskTransparency;
+int configOskTransparency;
 
 
 enum OSKTheme {
@@ -80,7 +80,7 @@ void initOsk(JSONValue oskJson) {
     configOskLayout = oskJson["layout"].str.toUpper.to!OSKLayout;
     configOskNumberRow = oskJson["numberRow"].boolean;
     configOskModifierNames = oskJson["modifierNames"].str.toUpper.to!OSKModifierNames;
-    updateOSKTransparency(oskJson["transparencyPercent"].str.to!int)
+    updateOSKTransparency(oskJson["transparencyPercent"].str.to!int);
 
     // Load fonts
     WIN_FONTS ~= CreateFont(0, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE, ANSI_CHARSET, OUT_DEFAULT_PRECIS,
@@ -214,9 +214,9 @@ void drawOsk(HWND hwnd, NeoLayout *layout, uint layer, bool capslock) {
     const float FONT_SIZE = 0.45;
     const float BASE_LINE = 0.7;
 
-    float transparency = configOskTransparency / 100.0
+    float transparency = configOskTransparency.to!float / 100.0;
     cairo_pattern_t *COLOR_GREY = cairo_pattern_create_rgba(0.4, 0.4, 0.4, transparency);
-    cairo_pattern_t *COLOR_GREY_2 = cairo_pattern_create_rgba(0.5, 0.5, 0.5, transparency);
+    cairo_pattern_t *COLOR_GREY_2 = cairo_pattern_create_rgba(0.6, 0.6, 0.6, transparency);
 
     cairo_pattern_t *COLOR_NEO_BLUE = cairo_pattern_create_rgba(0.024, 0.533, 0.612, transparency);
 
@@ -631,7 +631,7 @@ void centerOskOnScreen(HWND hwnd) {
 }
 
 void updateOSKTransparency(int diff) nothrow {
-    float newValue = configOskTransparency + diff;
+    int newValue = configOskTransparency + diff;
     if (newValue < 0) {
         newValue = 0;
     } else if (newValue > 100) {

--- a/source/osk.d
+++ b/source/osk.d
@@ -32,7 +32,7 @@ OSKTheme configOskTheme;
 OSKLayout configOskLayout;
 bool configOskNumberRow;
 OSKModifierNames configOskModifierNames;
-float configOskTransparancy;
+float configOskTransparency;
 
 
 enum OSKTheme {
@@ -80,12 +80,7 @@ void initOsk(JSONValue oskJson) {
     configOskLayout = oskJson["layout"].str.toUpper.to!OSKLayout;
     configOskNumberRow = oskJson["numberRow"].boolean;
     configOskModifierNames = oskJson["modifierNames"].str.toUpper.to!OSKModifierNames;
-    configOskTransparancy = (configOskTheme == OSKTheme.Grey) ? 0.9 : 0.95;
-    if (oskJson["transparency"].type == JSONType.float_) {
-        configOskTransparancy = oskJson["transparency"].floating;
-    } else if (oskJson["transparency"].type == JSONType.integer) {
-        configOskTransparancy = cast(float)oskJson["transparency"].integer;
-    }
+    updateOSKTransparency(oskJson["transparencyPercent"].str.to!int)
 
     // Load fonts
     WIN_FONTS ~= CreateFont(0, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE, ANSI_CHARSET, OUT_DEFAULT_PRECIS,
@@ -219,29 +214,31 @@ void drawOsk(HWND hwnd, NeoLayout *layout, uint layer, bool capslock) {
     const float FONT_SIZE = 0.45;
     const float BASE_LINE = 0.7;
 
-    cairo_pattern_t *COLOR_GREY = cairo_pattern_create_rgba(0.4, 0.4, 0.4, configOskTransparancy);
+    float transparency = configOskTransparency / 100.0
+    cairo_pattern_t *COLOR_GREY = cairo_pattern_create_rgba(0.4, 0.4, 0.4, transparency);
+    cairo_pattern_t *COLOR_GREY_2 = cairo_pattern_create_rgba(0.5, 0.5, 0.5, transparency);
 
-    cairo_pattern_t *COLOR_NEO_BLUE = cairo_pattern_create_rgba(0.024, 0.533, 0.612, configOskTransparancy);
+    cairo_pattern_t *COLOR_NEO_BLUE = cairo_pattern_create_rgba(0.024, 0.533, 0.612, transparency);
 
-    cairo_pattern_t *COLOR_NEOVARS_GREY = cairo_pattern_create_rgba(200.0/255.0, 200.0/255.0, 200.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_NEOVARS_YELLOW = cairo_pattern_create_rgba(235.0/255.0, 230.0/255.0, 150.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_NEOVARS_RED = cairo_pattern_create_rgba(231.0/255.0, 150.0/255.0, 153.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_NEOVARS_GREEN = cairo_pattern_create_rgba(117.0/255.0, 216.0/255.0, 157.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_NEOVARS_BLUE = cairo_pattern_create_rgba(134.0/255.0, 138.0/255.0, 223.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_NEOVARS_LIGHT_BLUE = cairo_pattern_create_rgba(197.0/255.0, 203.0/255.0, 255.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_NEOVARS_GREY = cairo_pattern_create_rgba(200.0/255.0, 200.0/255.0, 200.0/255.0, transparency);
+    cairo_pattern_t *COLOR_NEOVARS_YELLOW = cairo_pattern_create_rgba(235.0/255.0, 230.0/255.0, 150.0/255.0, transparency);
+    cairo_pattern_t *COLOR_NEOVARS_RED = cairo_pattern_create_rgba(231.0/255.0, 150.0/255.0, 153.0/255.0, transparency);
+    cairo_pattern_t *COLOR_NEOVARS_GREEN = cairo_pattern_create_rgba(117.0/255.0, 216.0/255.0, 157.0/255.0, transparency);
+    cairo_pattern_t *COLOR_NEOVARS_BLUE = cairo_pattern_create_rgba(134.0/255.0, 138.0/255.0, 223.0/255.0, transparency);
+    cairo_pattern_t *COLOR_NEOVARS_LIGHT_BLUE = cairo_pattern_create_rgba(197.0/255.0, 203.0/255.0, 255.0/255.0, transparency);
 
-    cairo_pattern_t *COLOR_GREEN_LIGHT_BLUE = cairo_pattern_create_rgba(147.0/255.0, 204.0/255.0, 234.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_GREEN_GREENISH_BLUE = cairo_pattern_create_rgba(122.0/255.0, 190.0/255.0, 179.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_GREEN_BLUEISH_GREEN = cairo_pattern_create_rgba(99.0/255.0, 178.0/255.0, 128.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_GREEN_GREEN = cairo_pattern_create_rgba(74.0/255.0, 164.0/255.0, 74.0/255.0, configOskTransparancy);
-    cairo_pattern_t *COLOR_GREEN_LIGHT_GREEN = cairo_pattern_create_rgba(139.0/255.0, 189.0/255.0, 139.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_GREEN_LIGHT_BLUE = cairo_pattern_create_rgba(147.0/255.0, 204.0/255.0, 234.0/255.0, transparency);
+    cairo_pattern_t *COLOR_GREEN_GREENISH_BLUE = cairo_pattern_create_rgba(122.0/255.0, 190.0/255.0, 179.0/255.0, transparency);
+    cairo_pattern_t *COLOR_GREEN_BLUEISH_GREEN = cairo_pattern_create_rgba(99.0/255.0, 178.0/255.0, 128.0/255.0, transparency);
+    cairo_pattern_t *COLOR_GREEN_GREEN = cairo_pattern_create_rgba(74.0/255.0, 164.0/255.0, 74.0/255.0, transparency);
+    cairo_pattern_t *COLOR_GREEN_LIGHT_GREEN = cairo_pattern_create_rgba(139.0/255.0, 189.0/255.0, 139.0/255.0, transparency);
 
     cairo_pattern_t *TEXT_COLOR;
 
     switch (configOskTheme) {
-        case OSKTheme.ColorClassic: TEXT_COLOR = cairo_pattern_create_rgba(0.05, 0.05, 0.05, configOskTransparancy + 0.05); break;
-        case OSKTheme.ColorGreen: TEXT_COLOR = cairo_pattern_create_rgba(0.05, 0.05, 0.05, configOskTransparancy + 0.05); break;
-        default: TEXT_COLOR = cairo_pattern_create_rgba(0.95, 0.95, 0.95, configOskTransparancy + 0.05);
+        case OSKTheme.ColorClassic: TEXT_COLOR = cairo_pattern_create_rgba(0.05, 0.05, 0.05, transparency + 0.05); break;
+        case OSKTheme.ColorGreen: TEXT_COLOR = cairo_pattern_create_rgba(0.05, 0.05, 0.05, transparency + 0.05); break;
+        default: TEXT_COLOR = cairo_pattern_create_rgba(0.95, 0.95, 0.95, transparency + 0.05);
     }
 
     cairo_set_font_size(cr, FONT_SIZE);
@@ -300,7 +297,14 @@ void drawOsk(HWND hwnd, NeoLayout *layout, uint layer, bool capslock) {
 
     cairo_pattern_t *getKeyColor(Scancode scan) {
         switch (configOskTheme) {
-            case OSKTheme.Grey: return COLOR_GREY;
+            case OSKTheme.Grey: 
+            {
+                auto keyType = KEY_TYPES.get(scan, OSKKeyType.OTHER);
+                switch (keyType) {
+                    case OSKKeyType.HOME: return COLOR_GREY_2;
+                    default: return COLOR_GREY;
+                }
+            }
             case OSKTheme.NeoBlue: return COLOR_NEO_BLUE;
             case OSKTheme.ColorClassic:
             {
@@ -624,4 +628,14 @@ void centerOskOnScreen(HWND hwnd) {
         workArea.left + (workArea.right - workArea.left - winWidth) / 2,
         workArea.bottom - winHeight - winBottomOffset,
         winWidth, winHeight, SWP_NOZORDER);
+}
+
+void updateOSKTransparency(int diff) nothrow {
+    float newValue = configOskTransparency + diff;
+    if (newValue < 0) {
+        newValue = 0;
+    } else if (newValue > 100) {
+        newValue = 100;
+    }
+    configOskTransparency = newValue;
 }

--- a/source/osk.d
+++ b/source/osk.d
@@ -32,6 +32,7 @@ OSKTheme configOskTheme;
 OSKLayout configOskLayout;
 bool configOskNumberRow;
 OSKModifierNames configOskModifierNames;
+float configOskTransparancy;
 
 
 enum OSKTheme {

--- a/source/osk.d
+++ b/source/osk.d
@@ -219,29 +219,29 @@ void drawOsk(HWND hwnd, NeoLayout *layout, uint layer, bool capslock) {
     const float FONT_SIZE = 0.45;
     const float BASE_LINE = 0.7;
 
-    cairo_pattern_t *COLOR_GREY = cairo_pattern_create_rgba(0.4, 0.4, 0.4, 0.9);
+    cairo_pattern_t *COLOR_GREY = cairo_pattern_create_rgba(0.4, 0.4, 0.4, configOskTransparancy);
 
-    cairo_pattern_t *COLOR_NEO_BLUE = cairo_pattern_create_rgba(0.024, 0.533, 0.612, 0.95);
+    cairo_pattern_t *COLOR_NEO_BLUE = cairo_pattern_create_rgba(0.024, 0.533, 0.612, configOskTransparancy);
 
-    cairo_pattern_t *COLOR_NEOVARS_GREY = cairo_pattern_create_rgba(200.0/255.0, 200.0/255.0, 200.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_NEOVARS_YELLOW = cairo_pattern_create_rgba(235.0/255.0, 230.0/255.0, 150.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_NEOVARS_RED = cairo_pattern_create_rgba(231.0/255.0, 150.0/255.0, 153.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_NEOVARS_GREEN = cairo_pattern_create_rgba(117.0/255.0, 216.0/255.0, 157.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_NEOVARS_BLUE = cairo_pattern_create_rgba(134.0/255.0, 138.0/255.0, 223.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_NEOVARS_LIGHT_BLUE = cairo_pattern_create_rgba(197.0/255.0, 203.0/255.0, 255.0/255.0, 0.95);
+    cairo_pattern_t *COLOR_NEOVARS_GREY = cairo_pattern_create_rgba(200.0/255.0, 200.0/255.0, 200.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_NEOVARS_YELLOW = cairo_pattern_create_rgba(235.0/255.0, 230.0/255.0, 150.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_NEOVARS_RED = cairo_pattern_create_rgba(231.0/255.0, 150.0/255.0, 153.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_NEOVARS_GREEN = cairo_pattern_create_rgba(117.0/255.0, 216.0/255.0, 157.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_NEOVARS_BLUE = cairo_pattern_create_rgba(134.0/255.0, 138.0/255.0, 223.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_NEOVARS_LIGHT_BLUE = cairo_pattern_create_rgba(197.0/255.0, 203.0/255.0, 255.0/255.0, configOskTransparancy);
 
-    cairo_pattern_t *COLOR_GREEN_LIGHT_BLUE = cairo_pattern_create_rgba(147.0/255.0, 204.0/255.0, 234.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_GREEN_GREENISH_BLUE = cairo_pattern_create_rgba(122.0/255.0, 190.0/255.0, 179.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_GREEN_BLUEISH_GREEN = cairo_pattern_create_rgba(99.0/255.0, 178.0/255.0, 128.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_GREEN_GREEN = cairo_pattern_create_rgba(74.0/255.0, 164.0/255.0, 74.0/255.0, 0.95);
-    cairo_pattern_t *COLOR_GREEN_LIGHT_GREEN = cairo_pattern_create_rgba(139.0/255.0, 189.0/255.0, 139.0/255.0, 0.95);
+    cairo_pattern_t *COLOR_GREEN_LIGHT_BLUE = cairo_pattern_create_rgba(147.0/255.0, 204.0/255.0, 234.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_GREEN_GREENISH_BLUE = cairo_pattern_create_rgba(122.0/255.0, 190.0/255.0, 179.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_GREEN_BLUEISH_GREEN = cairo_pattern_create_rgba(99.0/255.0, 178.0/255.0, 128.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_GREEN_GREEN = cairo_pattern_create_rgba(74.0/255.0, 164.0/255.0, 74.0/255.0, configOskTransparancy);
+    cairo_pattern_t *COLOR_GREEN_LIGHT_GREEN = cairo_pattern_create_rgba(139.0/255.0, 189.0/255.0, 139.0/255.0, configOskTransparancy);
 
     cairo_pattern_t *TEXT_COLOR;
 
     switch (configOskTheme) {
-        case OSKTheme.ColorClassic: TEXT_COLOR = cairo_pattern_create_rgba(0.05, 0.05, 0.05, 1.0); break;
-        case OSKTheme.ColorGreen: TEXT_COLOR = cairo_pattern_create_rgba(0.05, 0.05, 0.05, 1.0); break;
-        default: TEXT_COLOR = cairo_pattern_create_rgba(0.95, 0.95, 0.95, 1.0);
+        case OSKTheme.ColorClassic: TEXT_COLOR = cairo_pattern_create_rgba(0.05, 0.05, 0.05, configOskTransparancy + 0.05); break;
+        case OSKTheme.ColorGreen: TEXT_COLOR = cairo_pattern_create_rgba(0.05, 0.05, 0.05, configOskTransparancy + 0.05); break;
+        default: TEXT_COLOR = cairo_pattern_create_rgba(0.95, 0.95, 0.95, configOskTransparancy + 0.05);
     }
 
     cairo_set_font_size(cr, FONT_SIZE);

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -14,6 +14,7 @@ import core.sys.windows.windows;
 
 import mapping;
 import composer;
+import osk : updateOSKTransparency;
 import app : configAutoNumlock, configEnableMod4Lock, configFilterNeoModifiers, configOneHandedModeMirrorKey, configOneHandedModeMirrorMap, updateOSKAsync, toggleOSK, toggleOneHandedMode, lastInputLocale;
 
 const SC_FAKE_LSHIFT = 0x22A;
@@ -850,6 +851,16 @@ bool keyboardHook(WPARAM msgType, KBDLLHOOKSTRUCT msgStruct) nothrow {
     if (vk == VK_F1 && down && (isModifierHeld(Modifier.LMOD3) || isModifierHeld(Modifier.RMOD3))) {
         toggleOSK();
         return true;  // Eat F1
+    }
+    // Increase transparency of OSK on M3+F2
+    if (vk == VK_F2 && down && (isModifierHeld(Modifier.LMOD3) || isModifierHeld(Modifier.RMOD3))) {
+        updateOSKTransparency(-10);
+        return true;  // Eat F2
+    }
+    // Decrease transparency of OSK on M3+F2
+    if (vk == VK_F3 && down && (isModifierHeld(Modifier.LMOD3) || isModifierHeld(Modifier.RMOD3))) {
+        updateOSKTransparency(10);
+        return true;  // Eat F3
     }
 
     // Toggle one handed mode on M3+F10

--- a/source/reneo.d
+++ b/source/reneo.d
@@ -855,11 +855,13 @@ bool keyboardHook(WPARAM msgType, KBDLLHOOKSTRUCT msgStruct) nothrow {
     // Increase transparency of OSK on M3+F2
     if (vk == VK_F2 && down && (isModifierHeld(Modifier.LMOD3) || isModifierHeld(Modifier.RMOD3))) {
         updateOSKTransparency(-10);
+        updateOSKAsync();
         return true;  // Eat F2
     }
     // Decrease transparency of OSK on M3+F2
     if (vk == VK_F3 && down && (isModifierHeld(Modifier.LMOD3) || isModifierHeld(Modifier.RMOD3))) {
         updateOSKTransparency(10);
+        updateOSKAsync();
         return true;  // Eat F3
     }
 


### PR DESCRIPTION
I love this project, but found the need to change up the transparency of the osk while learning the layout (NeoQuertz, as i am mainly here for the symbol layer). Sooooo, i added it.

I also snuck in a little detail in the `GREY` Theme, to highlight the `HOME` keys, as i was getting confused where i am on the keyboard, when looking at other layers.

Happy for any kind of feedback and i can make adjustments if needed.